### PR TITLE
Support binding types that implement text encoding

### DIFF
--- a/bind_test.go
+++ b/bind_test.go
@@ -23,6 +23,7 @@ package flagbind
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -190,6 +191,7 @@ type ValidTestFlags struct {
 	String       string
 	Value        TestValue
 	ValueDefault TestValue `flag:";true;"`
+	Marshaler    TestTextMarshaler
 
 	IP  net.IP
 	IPs []net.IP
@@ -451,6 +453,27 @@ var tests = []BindTest{
 		ExpF: &struct {
 			http.Client
 		}{http.Client{Timeout: 5 * time.Second}},
+	}, {
+		Name: "Marshaler",
+		F: &struct {
+			E TestTextMarshaler `flag:"marshaler"`
+		}{},
+		ExpF: &struct {
+			E TestTextMarshaler `flag:"marshaler"`
+		}{E: TestTextMarshaler{v: "value"}},
+		ParseArgs: []string{
+			`-marshaler`, `value`,
+		},
+	}, {
+		Name: "Marshaler error",
+		F: &struct {
+			E TestTextMarshaler `flag:"marshaler"`
+		}{E: TestTextMarshaler{err: errors.New("bad")}},
+		ParseArgs: []string{
+			`-marshaler`, `value`,
+		},
+		ErrParse:      `invalid value "value" for flag -marshaler: bad`,
+		ErrPFlagParse: `invalid argument "value" for "--marshaler" flag: bad`,
 	},
 }
 

--- a/value.go
+++ b/value.go
@@ -1,6 +1,9 @@
 package flagbind
 
-import "encoding/json"
+import (
+	"encoding"
+	"encoding/json"
+)
 
 type JSONRawMessage json.RawMessage
 
@@ -13,3 +16,29 @@ func (data JSONRawMessage) String() string {
 }
 
 func (data JSONRawMessage) Type() string { return "JSON" }
+
+type pflagMarshalerValue struct {
+	marshaler textBidiMarshaler
+	typeStr   string
+}
+
+type textBidiMarshaler interface {
+	encoding.TextMarshaler
+	encoding.TextUnmarshaler
+}
+
+func (val pflagMarshalerValue) String() string {
+	text, err := val.marshaler.MarshalText()
+	if err != nil {
+		return "<invalid>"
+	}
+	return string(text)
+}
+
+func (val pflagMarshalerValue) Type() string {
+	return val.typeStr
+}
+
+func (val *pflagMarshalerValue) Set(v string) error {
+	return val.marshaler.UnmarshalText([]byte(v))
+}

--- a/value_test.go
+++ b/value_test.go
@@ -38,6 +38,21 @@ func (v *TestValue) Set(text string) error {
 	}
 	return nil
 }
+
 func (v TestValue) String() string {
 	return fmt.Sprint(bool(v))
+}
+
+type TestTextMarshaler struct {
+	v   string
+	err error
+}
+
+func (v *TestTextMarshaler) MarshalText() (text []byte, err error) {
+	return []byte(v.v), v.err
+}
+
+func (v *TestTextMarshaler) UnmarshalText(text []byte) error {
+	v.v = string(text)
+	return v.err
 }


### PR DESCRIPTION
I ran across this interface while trying to create a flag from a logrus.Level values, and thought it might make sense to support it directly in flagbind.